### PR TITLE
Changed NetworkLocum company id and name to Lantum due to our rebranding

### DIFF
--- a/public/data/london.json
+++ b/public/data/london.json
@@ -4252,8 +4252,8 @@
   ]
 },
 {
-  "id": "network-locum",
-  "name": "Network Locum",
+  "id": "lantum",
+  "name": "Lantum",
   "industry": "MedTech",
   "station": "Old Street",
   "address": "15 Bonhill Street, London. EC2A 4DN",


### PR DESCRIPTION
proof: http://techcitynews.com/press_release/leading-light-in-british-health-tech-network-locum-rebrands-to-lantum/