### PR TITLE
update lystable to kalohq

### DIFF
--- a/public/data/london.json
+++ b/public/data/london.json
@@ -2508,8 +2508,8 @@
   ]
 },
 {
-  "id": "lystable",
-  "name": "Lystable",
+  "id": "kalohq",
+  "name": "Kalohq",
   "industry": "HRTech",
   "station": "Coledonian Road & Barnsbury",
   "address": "39 Tileyard Rd, London N7 9AH,",


### PR DESCRIPTION
Lystable changed their name to Kalohq.
Please see below link to more detail
https://www.cnbc.com/2017/05/28/lystable-rebrands-as-kalo-building-linkedin-for-contractors.html
